### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/isbnlib/_exceptions.py
+++ b/isbnlib/_exceptions.py
@@ -10,7 +10,7 @@ def quiet_errors(exc_type, exc_value, traceback):
               from isbnlib import quiet_errors
               sys.excepthook = quiet_errors
     """
-    sys.stderr.write('Error: %s\n' % exc_value)  # pragma: no cover
+    sys.stderr.write('Error: {0!s}\n'.format(exc_value))  # pragma: no cover
 
 
 class ISBNLibException(Exception):
@@ -28,14 +28,14 @@ class NotRecognizedServiceError(ISBNLibException):
     """Exception raised when the service is not in config.py."""
 
     def __init__(self, service):
-        self.message = "(%s) is not a recognized service" % service
+        self.message = "({0!s}) is not a recognized service".format(service)
 
 
 class NotValidISBNError(ISBNLibException):
     """Exception raised when the ISBN is not valid."""
 
     def __init__(self, isbnlike):
-        self.message = "(%s) is not a valid ISBN" % isbnlike
+        self.message = "({0!s}) is not a valid ISBN".format(isbnlike)
 
 
 class PluginNotLoadedError(ISBNLibException):  # pragma: no cover
@@ -45,4 +45,4 @@ class PluginNotLoadedError(ISBNLibException):  # pragma: no cover
     """
 
     def __init__(self, path):
-        self.message = "plugin (%s) wasn't loaded" % path
+        self.message = "plugin ({0!s}) wasn't loaded".format(path)

--- a/isbnlib/_ext.py
+++ b/isbnlib/_ext.py
@@ -46,8 +46,8 @@ def isbn_from_words(words):
 
 def doi(isbn):
     """Return a DOI's ISBN-A from a ISBN-13."""
-    return "10.%s.%s%s/%s%s" % \
-           tuple(msk(EAN13(isbn), '-').split('-'))
+    return "10.{0!s}.{1!s}{2!s}/{3!s}{4!s}".format(* \
+           tuple(msk(EAN13(isbn), '-').split('-')))
 
 
 def ren(fp):
@@ -76,7 +76,7 @@ def ren(fp):
         stitle = cutoff_tokens(tokens, maxlen)
         title = ' '.join(stitle)
     isbn13 = data.get('ISBN-13', u('UNKNOWN'))
-    new_name = "%s%s_%s_%s" % (author, year, title, isbn13)
+    new_name = "{0!s}{1!s}_{2!s}_{3!s}".format(author, year, title, isbn13)
     return cfp.baserename(b2u3(new_name + cfp.ext))
 
 

--- a/isbnlib/_goob.py
+++ b/isbnlib/_goob.py
@@ -52,7 +52,7 @@ def _records(isbn, data):
         if u('ISBN_13') in repr(ids) and \
            isbn not in repr(ids):  # pragma: no cover
             LOGGER.debug('ISBNNotConsistentError for %s (%s)', isbn, repr(ids))
-            raise ISBNNotConsistentError("%s not in %s" % (isbn, repr(ids)))
+            raise ISBNNotConsistentError("{0!s} not in {1!s}".format(isbn, repr(ids)))
     # map canonical <- records
     return _mapper(isbn, recs)
 

--- a/isbnlib/_isbndb.py
+++ b/isbnlib/_isbndb.py
@@ -52,7 +52,7 @@ def _records(isbn, data):
             raise
     except:
         LOGGER.debug('DataWrongShapeError for %s with status %s', isbn, err)
-        raise DataWrongShapeError("error: '%s' for isbn %s" % (err, isbn))
+        raise DataWrongShapeError("error: '{0!s}' for isbn {1!s}".format(err, isbn))
     # put the selected data in records
     try:
         recs = data['data'][0]
@@ -64,7 +64,7 @@ def _records(isbn, data):
         ids = recs.get('isbn13', '')
         if isbn not in repr(ids):  # pragma: no cover
             LOGGER.debug('ISBNNotConsistentError for %s (%s)', isbn, repr(ids))
-            raise ISBNNotConsistentError("%s not in %s" % (isbn, repr(ids)))
+            raise ISBNNotConsistentError("{0!s} not in {1!s}".format(isbn, repr(ids)))
     # map canonical <- records
     return _mapper(isbn, recs)
 

--- a/isbnlib/_openl.py
+++ b/isbnlib/_openl.py
@@ -46,7 +46,7 @@ def _records(isbn, data):
     """Classify (canonically) the parsed data."""
     try:
         # put the selected data in records
-        records = data['ISBN:%s' % isbn]
+        records = data['ISBN:{0!s}'.format(isbn)]
     except:  # pragma: no cover
         LOGGER.debug('NoDataForSelectorError for %s', isbn)
         raise NoDataForSelectorError(isbn)

--- a/isbnlib/dev/_exceptions.py
+++ b/isbnlib/dev/_exceptions.py
@@ -14,7 +14,7 @@ class ISBNLibDevException(Exception):
 
     def __init__(self, msg=None):
         if msg:
-            self.message = '%s (%s)' % (self.message, msg)
+            self.message = '{0!s} ({1!s})'.format(self.message, msg)
 
     def __str__(self):
         return getattr(self, 'message', '')  # pragma: no cover

--- a/isbnlib/dev/_helpers.py
+++ b/isbnlib/dev/_helpers.py
@@ -10,7 +10,7 @@ from ._bouth23 import b, s
 
 def fake_isbn(title, author='unkown', publisher='unkown', sid=1):
     """Produce a fake ISBN from the (title, author, publisher) of the book."""
-    key = "%s %s %s" % (title, author, publisher)
+    key = "{0!s} {1!s} {2!s}".format(title, author, publisher)
     # normalize
     regex1 = re.compile(r'\?|,|\.|!|\:|;', re.I | re.M | re.S)
     regex2 = re.compile(r'\s\s+', re.I | re.M | re.S)

--- a/isbnlib/dev/webservice.py
+++ b/isbnlib/dev/webservice.py
@@ -46,12 +46,12 @@ class WEBService(object):
             LOGGER.critical('ISBNLibHTTPError for %s with code %s [%s]',
                             self._url, e.code, e.msg)
             if e.code in (401, 403, 429):
-                raise ISBNLibHTTPError('%s Are you making many requests?' %
-                                       e.code)
+                raise ISBNLibHTTPError('{0!s} Are you making many requests?'.format(
+                                       e.code))
             if e.code in (502, 504):
-                raise ISBNLibHTTPError('%s Service temporarily unavailable!' %
-                                       e.code)
-            raise ISBNLibHTTPError('(%s) %s' % (e.code, e.msg))
+                raise ISBNLibHTTPError('{0!s} Service temporarily unavailable!'.format(
+                                       e.code))
+            raise ISBNLibHTTPError('({0!s}) {1!s}'.format(e.code, e.msg))
         except URLError as e:  # pragma: no cover
             LOGGER.critical('ISBNLibURLError for %s with reason %s', self._url,
                             e.reason)

--- a/isbnlib/test/test_files.py
+++ b/isbnlib/test/test_files.py
@@ -16,8 +16,7 @@ if ENCODING == 'UTF-8':
     TESTFILE = './ç-deleteme.pdf' if WINDOWS else '/tmp/海明威-deleteme.pdf'
     NEW_BASENAME = 'ç-deleteme-PLEASE.pdf' if WINDOWS else '海明威-deleteme-PLEASE.pdf'
 else:
-    print("Your default locale encoding (%s) doesn't allow unicode filenames!"
-          % ENCODING)
+    print("Your default locale encoding ({0!s}) doesn't allow unicode filenames!".format(ENCODING))
     TESTFILE = './deleteme.pdf'
     NEW_BASENAME = 'deleteme-PLEASE.pdf'
 

--- a/isbnlib/test/test_rename.py
+++ b/isbnlib/test/test_rename.py
@@ -15,8 +15,7 @@ nose tests
 WINDOWS = os.name == 'nt'
 ENCODING = locale.getpreferredencoding()
 if ENCODING != 'UTF-8':
-    print("Your default locale encoding (%s) doesn't allow unicode filenames!"
-          % ENCODING)
+    print("Your default locale encoding ({0!s}) doesn't allow unicode filenames!".format(ENCODING))
     print("=> Some tests could fail.")
 
 TESTFILE_1 = './ç-deleteme.pdf' if WINDOWS else '/tmp/ç-deleteme.pdf'
@@ -48,8 +47,7 @@ def create_files(files):
             with open(fn, 'w') as f:
                 f.write(b2u3('ooo') + b2u3(fn))
         except UnicodeEncodeError:
-            print("Your default locale (%s) doesn't allow non-ascii filenames!"
-                  % locale.CODESET)
+            print("Your default locale ({0!s}) doesn't allow non-ascii filenames!".format(locale.CODESET))
 
 
 def delete_files(fnpatt):


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:xlcnd:isbnlib?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:xlcnd:isbnlib?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)