### PR TITLE
WebService: when sending values throws TypeError

### DIFF
--- a/isbnlib/dev/webservice.py
+++ b/isbnlib/dev/webservice.py
@@ -36,7 +36,7 @@ class WEBService(object):
         if appheaders:  # pragma: no cover
             headers.update(appheaders)
         # if 'data' it does a PUT request (data must be urlencoded)
-        data = urlencode(values) if values else None
+        data = urlencode(values).encode('utf8') if values else None
         self._request = Request(url, data, headers=headers)
         self.response = None
 

--- a/isbnlib/test/test_webservice.py
+++ b/isbnlib/test/test_webservice.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# flake8: noqa
+# pylint: skip-file
+"""
+nose tests
+"""
+
+from ..dev.webservice import query as wsquery
+from nose.tools import assert_equals
+
+
+def test_webservice():
+    """Test that values can be passed to a WebService query."""
+    assert_equals(len(repr(wsquery("http://example.org", values={'some': 'values'}))) > 0,
+                  True)


### PR DESCRIPTION
While running on python 3 ( 3.5.2 ), a _WebService_ cannot be used to send values a `TypeError` is thrown.

```
Python 3.5.2 (default, Nov  7 2016, 11:31:36) 
[GCC 6.2.1 20160830] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from isbnlib.dev.webservice import query as wsquery
>>> wsquery("http://php.chimbori.com/_php/isbn/isbn-bibtex", values={'isbn': '9780131103627'})
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/nickcis/repos/isbnlib/isbnlib/dev/webservice.py", line 83, in query
    data = service.data()
  File "/home/nickcis/repos/isbnlib/isbnlib/dev/webservice.py", line 66, in data
    self._response()
  File "/home/nickcis/repos/isbnlib/isbnlib/dev/webservice.py", line 47, in _response
    timeout=config.SOCKETS_TIMEOUT)
  File "/usr/lib/python3.5/urllib/request.py", line 163, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/lib/python3.5/urllib/request.py", line 464, in open
    req = meth(req)
  File "/usr/lib/python3.5/urllib/request.py", line 1183, in do_request_
    raise TypeError(msg)
TypeError: POST data should be bytes or an iterable of bytes. It cannot be of type str.
```

`urlencode` returns a `str` and `bytes` should be passed to the `Request` object. The patch assumes utf-8 encoding