### PR TITLE
Include LICENSE in PyPI tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include *.txt
 include *.rst
 include *.coveragerc
+include LICENSE


### PR DESCRIPTION
Without, installation fails with `error: [Errno 2] No such file or directory: 'LICENSE'`