### PR TITLE
basictests.yml: Test on Python 3.9 and upgrade actions/setup-python

### DIFF
--- a/.github/workflows/basictests.yml
+++ b/.github/workflows/basictests.yml
@@ -6,21 +6,18 @@ on:
   schedule:
   - cron: '15 5 * * *'
 
-
 jobs:
-
   basic-tests-linux:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.8]
+        python-version: [3.6, 3.9]
     env:
       GITHUB_OS: linux
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -39,19 +36,17 @@ jobs:
         pip install nose coverage
         nosetests -v --with-coverage --cover-package=isbnlib --cover-min-percentage=90
 
-
   basic-tests-macos:
-
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: [3.8]
     env:
       GITHUB_OS: macos
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -63,19 +58,17 @@ jobs:
         pip install nose coverage
         nosetests -v --with-coverage --cover-package=isbnlib --cover-min-percentage=90
 
-
   basic-tests-windows:
-
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: [3.8]
     env:
       GITHUB_OS: windows
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies


### PR DESCRIPTION
**IMPORTANT**

Make your pull request against the ``dev`` branch, please!

https://github.com/actions/setup-python/releases

There were three sets of pickle changes in Python 3.8: https://docs.python.org/3/whatsnew/3.8.html
> The default protocol in the pickle module is now Protocol 4, first introduced in Python 3.4. It offers better performance and smaller size compared to Protocol 3 available since Python 3.0.

Might be causing the macOS test 'vias' (multi) failure.


On follow-up of issue #???


Changes proposed in this pull request:

-

-

-


@xlcnd
