### PR TITLE
AppVeyor runs tox on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,24 @@
+# appveyor.yml - https://www.appveyor.com/docs/lang/python
+---
+image:
+  - Visual Studio 2019
+
+environment:
+  matrix:
+  # - TOXENV: py27  # https://devguide.python.org/devcycle/#end-of-life-branches
+  # - TOXENV: py35
+  - TOXENV: py36    # https://devguide.python.org/#status-of-python-branches
+  - TOXENV: py37
+  - TOXENV: py38
+  - TOXENV: py39
+  # - TOXENV: py310  # nose.tools.assert_equals() is not Py3.10 compatible
+
+build: false
+
+install:
+  # - py --list
+  # - py -m pip install --upgrade pip
+  - py -m pip install tox
+
+test_script:
+  - py -m tox

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 # appveyor.yml - https://www.appveyor.com/docs/lang/python
 ---
 image:
-  - Visual Studio 2019
+  - Visual Studio 2019  # https://www.appveyor.com/docs/windows-images-software/#python
 
 environment:
   matrix:
@@ -9,8 +9,8 @@ environment:
   # - TOXENV: py35
   - TOXENV: py36    # https://devguide.python.org/#status-of-python-branches
   - TOXENV: py37
-  - TOXENV: py38
-  - TOXENV: py39
+  # - TOXENV: py38
+  # - TOXENV: py39
   # - TOXENV: py310  # nose.tools.assert_equals() is not Py3.10 compatible
 
 build: false


### PR DESCRIPTION
**IMPORTANT**

Make your pull request against the ``dev`` branch, please!


On follow-up of issue #???


Changes proposed in this pull request:

- Fix the AppVeyor crash on all pull requests

- AppVeyor will run tox tests on py3.{6,7,8,9}

- Python 3.10 is not possible because `nose.tools.assert_equals()` is not Py3.10 compatible


@xlcnd
