### PR TITLE
Test modification

### DIFF
--- a/isbnlib/test/test_cache.py
+++ b/isbnlib/test/test_cache.py
@@ -38,5 +38,6 @@ def test_cache_contains():
 
 def test_cache_del():
     """Test 'cache' operations (del)."""
+    cache['567'] = 'jkl'
     del cache['567']
     assert_equals('567' not in cache, True)


### PR DESCRIPTION
when running pytest --flake-finder to find possible flaky tests, the test ```test_cache_del()``` run multiple times, the key was deleted in the previous run so if we run it again it will throw an error. It also fails if only run this specific function without running previous tests. So it is better to assign key-value pair right before the ```del``` statement.