### PR TITLE
nose2pytest: Upgrade Python testing from nose to pytest

### DIFF
--- a/.github/workflows/basictests.yml
+++ b/.github/workflows/basictests.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Test with pytest
       run: |
         pip install pytest coverage
-        pytest --ignore=isbnlib/test/test_openl.py
+        pytest --ignore=isbnlib/test/test_editions.py --ignore=isbnlib/test/test_openl.py
         # pytest -v --with-coverage --cover-package=isbnlib --cover-min-percentage=90
 
   basic-tests-macos:
@@ -58,7 +58,7 @@ jobs:
     - name: Test with pytest
       run: |
         pip install pytest coverage
-        pytest --ignore=isbnlib/test/test_openl.py
+        pytest --ignore=isbnlib/test/test_editions.py --ignore=isbnlib/test/test_openl.py
         # pytest -v --with-coverage --cover-package=isbnlib --cover-min-percentage=90
 
   basic-tests-windows:
@@ -81,5 +81,5 @@ jobs:
     - name: Test with pytest
       run: |
         pip install pytest coverage
-        pytest --ignore=isbnlib/test/test_openl.py
+        pytest --ignore=isbnlib/test/test_editions.py --ignore=isbnlib/test/test_openl.py
         # pytest -v --with-coverage --cover-package=isbnlib --cover-min-percentage=30

--- a/.github/workflows/basictests.yml
+++ b/.github/workflows/basictests.yml
@@ -58,7 +58,7 @@ jobs:
     - name: Test with pytest
       run: |
         pip install pytest coverage
-        pytest --ignore=isbnlib/test/test_openl.py --ignore=isbnlib/test/test_editions.py
+        pytest --ignore=isbnlib/test/test_openl.py
         # pytest -v --with-coverage --cover-package=isbnlib --cover-min-percentage=90
 
   basic-tests-windows:
@@ -81,5 +81,5 @@ jobs:
     - name: Test with pytest
       run: |
         pip install pytest coverage
-        pytest --ignore=isbnlib/test/test_openl.py --ignore=isbnlib/test/test_editions.py
+        pytest --ignore=isbnlib/test/test_openl.py
         # pytest -v --with-coverage --cover-package=isbnlib --cover-min-percentage=30

--- a/.github/workflows/basictests.yml
+++ b/.github/workflows/basictests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.6', '3.8', '3.10', '3.11-dev'] 
+        python-version: ['3.6', '3.8', '3.10', '3.11-dev', 'pypy3.9']
     env:
       GITHUB_OS: linux
     steps:

--- a/.github/workflows/basictests.yml
+++ b/.github/workflows/basictests.yml
@@ -10,8 +10,9 @@ jobs:
   basic-tests-linux:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: [3.6, 3.9]
+        python-version: ['3.6', '3.8', '3.10', '3.11-dev']
     env:
       GITHUB_OS: linux
     steps:
@@ -31,16 +32,17 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test with nose
+    - name: Test with pytest
       run: |
-        pip install nose coverage
-        nosetests -v --with-coverage --cover-package=isbnlib --cover-min-percentage=90
+        pip install pytest coverage
+        pytest --ignore=isbnlib/test/test_openl.py
+        # pytest -v --with-coverage --cover-package=isbnlib --cover-min-percentage=90
 
   basic-tests-macos:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.x]
     env:
       GITHUB_OS: macos
     steps:
@@ -53,16 +55,17 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-    - name: Test with nose
+    - name: Test with pytest
       run: |
-        pip install nose coverage
-        nosetests -v --with-coverage --cover-package=isbnlib --cover-min-percentage=90
+        pip install pytest coverage
+        pytest --ignore=isbnlib/test/test_openl.py
+        # pytest -v --with-coverage --cover-package=isbnlib --cover-min-percentage=90
 
   basic-tests-windows:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.x]
     env:
       GITHUB_OS: windows
     steps:
@@ -75,7 +78,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-    - name: Test with nose
+    - name: Test with pytest
       run: |
-        pip install nose coverage
-        nosetests -v --with-coverage --cover-package=isbnlib --cover-min-percentage=30
+        pip install pytest coverage
+        pytest --ignore=isbnlib/test/test_openl.py
+        # pytest -v --with-coverage --cover-package=isbnlib --cover-min-percentage=30

--- a/.github/workflows/basictests.yml
+++ b/.github/workflows/basictests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.6', '3.8', '3.10', '3.11-dev']
+        python-version: ['3.6', '3.8', '3.10', '3.11-dev'] 
     env:
       GITHUB_OS: linux
     steps:

--- a/.github/workflows/basictests.yml
+++ b/.github/workflows/basictests.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Test with pytest
       run: |
         pip install pytest coverage
-        pytest --ignore=isbnlib/test/test_openl.py
+        pytest --ignore=isbnlib/test/test_openl.py --ignore=isbnlib/test/test_editions.py
         # pytest -v --with-coverage --cover-package=isbnlib --cover-min-percentage=90
 
   basic-tests-macos:
@@ -58,7 +58,7 @@ jobs:
     - name: Test with pytest
       run: |
         pip install pytest coverage
-        pytest --ignore=isbnlib/test/test_openl.py
+        pytest --ignore=isbnlib/test/test_openl.py --ignore=isbnlib/test/test_editions.py
         # pytest -v --with-coverage --cover-package=isbnlib --cover-min-percentage=90
 
   basic-tests-windows:
@@ -81,5 +81,5 @@ jobs:
     - name: Test with pytest
       run: |
         pip install pytest coverage
-        pytest --ignore=isbnlib/test/test_openl.py
+        pytest --ignore=isbnlib/test/test_openl.py --ignore=isbnlib/test/test_editions.py
         # pytest -v --with-coverage --cover-package=isbnlib --cover-min-percentage=30

--- a/.github/workflows/basictests.yml
+++ b/.github/workflows/basictests.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Test with pytest
       run: |
         pip install pytest coverage
-        pytest --ignore=isbnlib/test/test_openl.py --ignore=isbnlib/test/test_editions.py
+        pytest --ignore=isbnlib/test/test_openl.py
         # pytest -v --with-coverage --cover-package=isbnlib --cover-min-percentage=90
 
   basic-tests-macos:

--- a/.github/workflows/basictests.yml
+++ b/.github/workflows/basictests.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: [3.x]
+        python-version: [3.8]
     env:
       GITHUB_OS: macos
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,10 +20,10 @@ adventure in open-source.
 5. Do your code... (**remember the code must run on python 3.6+
    and be OS independent**, you will find [Github Actions](https://docs.github.com/en/actions) very handy for
    testing with this requirement!)
-6. Write tests for your code using `nose` and put then in the directory `isbnlib/test`
+6. Write tests for your code using `pytest` and put then in the directory `isbnlib/test`
 7. Pass **all tests** and with **coverage > 90%**.
    Check the coverage locally with the command
-   `nosetests --with-coverage --cover-package=isbnlib`.
+   `pytest --with-coverage --cover-package=isbnlib`.
 8. **Check if all requirements are fulfilled**!
 9. **Push** your local changes to GitHub and make there a **pull request**
    ([help](https://help.github.com/articles/using-pull-requests/))

--- a/isbnlib/test/test_cache.py
+++ b/isbnlib/test/test_cache.py
@@ -3,8 +3,6 @@
 # pylint: skip-file
 """Tests for the cache."""
 
-from nose.tools import assert_equals
-
 from .._imcache import IMCache
 
 cache = IMCache()
@@ -21,23 +19,23 @@ def teardown_module():
 def test_cache_set():
     """Test 'cache' operations (set)."""
     cache['567'] = 'jkl'
-    assert_equals('jkl' == cache['567'], True)
+    assert ('jkl' == cache['567']) == True
 
 
 def test_cache_get():
     """Test 'cache' operations (get)."""
-    assert_equals(cache.get('123'), cache['123'])
-    assert_equals(cache.get('000'), None)
-    assert_equals(cache.get('000', ''), '')
+    assert cache.get('123') == cache['123']
+    assert cache.get('000') == None
+    assert cache.get('000', '') == ''
 
 
 def test_cache_contains():
     """Test 'cache' operations (contains)."""
-    assert_equals('123' in cache, True)
+    assert ('123' in cache) == True
 
 
 def test_cache_del():
     """Test 'cache' operations (del)."""
     cache['567'] = 'jkl'
     del cache['567']
-    assert_equals('567' not in cache, True)
+    assert ('567' not in cache) == True

--- a/isbnlib/test/test_cache_decorator.py
+++ b/isbnlib/test/test_cache_decorator.py
@@ -5,8 +5,6 @@
 
 # TODO add more tests for other operations
 
-from nose.tools import assert_equals
-
 from .. import classify, meta, registry
 
 cache = registry.metadata_cache
@@ -23,13 +21,11 @@ def teardown_module():
 
 def test_cache_meta():
     """Test '@cache' meta."""
-    assert_equals(
-        len(repr(cache.get("query('9780375869020', 'default'){}"))) > 100, True,
-    )
-    assert_equals(
-        len(repr(cache.get("query('9780375869020', 'default'){}"))),
-        len(repr(cache["query('9780375869020', 'default'){}"])),
-    )
+    assert (
+        (len(repr(cache.get("query('9780375869020', 'default'){}"))) > 100) == True)
+    assert (
+        len(repr(cache.get("query('9780375869020', 'default'){}"))) ==
+        len(repr(cache["query('9780375869020', 'default'){}"])))
 
 
 # def test_cache_classify():

--- a/isbnlib/test/test_classify.py
+++ b/isbnlib/test/test_classify.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 # flake8: noqa
 # pylint: skip-file
-"""nose tests for classifiers."""
-
-from nose.tools import assert_equals
+"""tests for classifiers."""
 
 from .._oclc import query_classify as query
 
@@ -16,42 +14,42 @@ q2 = query('9780425284629') or {}
 
 def test_query():
     """Test the query of classifiers (oclc.org) with 'low level' queries."""
-    assert_equals(len(repr(query('9782253112105'))) > 10, True)
-    assert_equals(len(repr(q1)) > 10, True)
-    assert_equals(len(repr(q2)) > 10, True)
+    assert (len(repr(query('9782253112105'))) > 10) == True
+    assert (len(repr(q1)) > 10) == True
+    assert (len(repr(q2)) > 10) == True
 
 
 def test_query_no_data():
     """Test the query of classifiers (oclc.org) with 'low level' queries (no data)."""
-    assert_equals(len(repr(query('9781849692341'))) == 2, True)
-    assert_equals(len(repr(query('9781849692343'))) == 2, True)
+    assert (len(repr(query('9781849692341'))) == 2) == True
+    assert (len(repr(query('9781849692343'))) == 2) == True
 
 
 def test_query_exists_ddc():
     """Test exists 'DDC'."""
-    assert_equals(len(repr(q1['ddc'])) > 2, True)
-    assert_equals(len(repr(q2['ddc'])) > 2, True)
+    assert (len(repr(q1['ddc'])) > 2) == True
+    assert (len(repr(q2['ddc'])) > 2) == True
 
 
 def test_query_exists_lcc():
     """Test exists 'LCC'."""
-    assert_equals(len(repr(q1['lcc'])) > 2, True)
-    assert_equals(len(repr(q2['lcc'])) > 2, True)
+    assert (len(repr(q1['lcc'])) > 2) == True
+    assert (len(repr(q2['lcc'])) > 2) == True
 
 
 def test_query_fast():
     """Test exists 'fast' classifiers."""
-    assert_equals(len(repr(q1['fast'])) > 7, True)
-    assert_equals(len(repr(q2['fast'])) > 7, True)
+    assert (len(repr(q1['fast'])) > 7) == True
+    assert (len(repr(q2['fast'])) > 7) == True
 
 
 def test_query_owi():
     """Test exists 'owi' classifiers."""
-    assert_equals(len(repr(q1['owi'])) > 5, True)
-    assert_equals(len(repr(q2['owi'])) > 5, True)
+    assert (len(repr(q1['owi'])) > 5) == True
+    assert (len(repr(q2['owi'])) > 5) == True
 
 
 def test_query_oclc():
     """Test exists 'oclc' classifiers."""
-    assert_equals(len(repr(q1['oclc'])) > 7, True)
-    assert_equals(len(repr(q2['oclc'])) > 7, True)
+    assert (len(repr(q1['oclc'])) > 7) == True
+    assert (len(repr(q2['oclc'])) > 7) == True

--- a/isbnlib/test/test_core.py
+++ b/isbnlib/test/test_core.py
@@ -2,8 +2,6 @@
 # flake8: noqa
 # pylint: skip-file
 
-from nose.tools import assert_equals
-
 from .._core import (
     EAN13,
     _check_structure10,
@@ -23,159 +21,158 @@ from .._core import (
 )
 from .data4tests import ISBNs
 
-# nose tests
+# tests
 
 
 def test_check_digit10():
     """Test check digit algo for ISBN-10."""
-    assert_equals(check_digit10('082649752'), '7')
-    assert_equals(check_digit10('585270001'), '0')
-    assert_equals(check_digit10('08264975X'), '')
-    assert_equals(check_digit10('08264975'), '')
+    assert check_digit10('082649752') == '7'
+    assert check_digit10('585270001') == '0'
+    assert check_digit10('08264975X') == ''
+    assert check_digit10('08264975') == ''
 
 
 def test_check_digit13():
     """Test check digit algo for ISBN-13."""
-    assert_equals(check_digit13('978082649752'), '9')
-    assert_equals(check_digit13('97808264975'), '')
-    assert_equals(check_digit13('97808264975X'), '')
+    assert check_digit13('978082649752') == '9'
+    assert check_digit13('97808264975') == ''
+    assert check_digit13('97808264975X') == ''
 
 
 def test__check_structure10():
     """Test structure detection for ISBN-10."""
-    assert_equals(_check_structure10('0826497527'), True)
-    assert_equals(_check_structure10('0826497X27'), True)  # isbnlike!
-    assert_equals(_check_structure10('0826497XI7'), False)
+    assert _check_structure10('0826497527') == True
+    assert _check_structure10('0826497X27') == True  # isbnlike!
+    assert _check_structure10('0826497XI7') == False
 
 
 def test__check_structure13():
     """Test structure detection for ISBN-13."""
-    assert_equals(_check_structure13('9780826497529'), True)
-    assert_equals(_check_structure13('978082649752X'), False)
+    assert _check_structure13('9780826497529') == True
+    assert _check_structure13('978082649752X') == False
 
 
 def test_is_isbn10():
     """Test detection and validation for ISBN-10."""
-    assert_equals(is_isbn10('0826497527'), True)
-    assert_equals(is_isbn10('isbn 0-8264-9752-7'), True)
-    assert_equals(is_isbn10('0826497520'), False)
-    assert_equals(is_isbn10('954430603X'), True)
+    assert is_isbn10('0826497527') == True
+    assert is_isbn10('isbn 0-8264-9752-7') == True
+    assert is_isbn10('0826497520') == False
+    assert is_isbn10('954430603X') == True
 
 
 def test_is_isbn13():
     """Test detection and validation for ISBN-13."""
-    assert_equals(is_isbn13('9780826497529'), True)
-    assert_equals(is_isbn13('9791090636071'), True)
-    assert_equals(is_isbn13('isbn 979-10-90636-07-1'), True)
-    assert_equals(is_isbn13('9780826497520'), False)
-    assert_equals(is_isbn13('9700000000000'), False)
-    assert_equals(is_isbn13('9000000000000'), False)
-    assert_equals(is_isbn13('9710000000000'), False)
+    assert is_isbn13('9780826497529') == True
+    assert is_isbn13('9791090636071') == True
+    assert is_isbn13('isbn 979-10-90636-07-1') == True
+    assert is_isbn13('9780826497520') == False
+    assert is_isbn13('9700000000000') == False
+    assert is_isbn13('9000000000000') == False
+    assert is_isbn13('9710000000000') == False
 
 
 def test_to_isbn10():
     """Test transformation of ISBN to ISBN-10."""
-    assert_equals(to_isbn10('9780826497529'), '0826497527')
-    assert_equals(to_isbn10('0826497527'), '0826497527')
-    assert_equals(to_isbn10('9780826497520'), '')  # ISBN13 not valid
-    assert_equals(to_isbn10('9790826497529'), '')
-    assert_equals(to_isbn10('97808264975X3'), '')
-    assert_equals(to_isbn10('978-826497'), '')  # (bug #14)
-    assert_equals(to_isbn10('isbn 0-8264-9752-7'), '0826497527')
-    assert_equals(to_isbn10('isbn 979-10-90636-07-1'), '')
-    assert_equals(to_isbn10('isbn 978-0-8264-9752-9'), '0826497527')
-    assert_equals(to_isbn10('asdadv isbn 978-0-8264-9752-9'), '0826497527')
+    assert to_isbn10('9780826497529') == '0826497527'
+    assert to_isbn10('0826497527') == '0826497527'
+    assert to_isbn10('9780826497520') == ''  # ISBN13 not valid
+    assert to_isbn10('9790826497529') == ''
+    assert to_isbn10('97808264975X3') == ''
+    assert to_isbn10('978-826497') == ''  # (bug #14)
+    assert to_isbn10('isbn 0-8264-9752-7') == '0826497527'
+    assert to_isbn10('isbn 979-10-90636-07-1') == ''
+    assert to_isbn10('isbn 978-0-8264-9752-9') == '0826497527'
+    assert to_isbn10('asdadv isbn 978-0-8264-9752-9') == '0826497527'
 
 
 def test_to_isbn13():
     """Test transformation of ISBN to ISBN-13."""
-    assert_equals(to_isbn13('0826497527'), '9780826497529')
-    assert_equals(to_isbn13('9780826497529'), '9780826497529')
-    assert_equals(to_isbn13('0826497520'), '')  # ISBN10 not valid
-    assert_equals(to_isbn13('08X6497527'), '')
-    assert_equals(to_isbn13('91-43-01019-9'), '9789143010190')  # (bug #14)
-    assert_equals(to_isbn13('isbn 91-43-01019-9'), '9789143010190')
-    assert_equals(to_isbn13('asd isbn 979-10-90636-07-1 blabla'), '9791090636071')
+    assert to_isbn13('0826497527') == '9780826497529'
+    assert to_isbn13('9780826497529') == '9780826497529'
+    assert to_isbn13('0826497520') == ''  # ISBN10 not valid
+    assert to_isbn13('08X6497527') == ''
+    assert to_isbn13('91-43-01019-9') == '9789143010190'  # (bug #14)
+    assert to_isbn13('isbn 91-43-01019-9') == '9789143010190'
+    assert to_isbn13('asd isbn 979-10-90636-07-1 blabla') == '9791090636071'
 
 
 def test_clean():
     """Test the cleaning of ISBN-like strings."""
-    assert_equals(clean(' 978.0826.497529'), '9780826497529')
-    assert_equals(clean('ISBN: 9791090636071'), 'ISBN 9791090636071')
-    assert_equals(clean('978,0826497520'), '9780826497520')
+    assert clean(' 978.0826.497529') == '9780826497529'
+    assert clean('ISBN: 9791090636071') == 'ISBN 9791090636071'
+    assert clean('978,0826497520') == '9780826497520'
 
 
 def test_notisbn():
     """Test the impossibility of extracting valid ISBN from ISBN-like strings."""
-    assert_equals(notisbn('0826497527'), False)
-    assert_equals(notisbn('0826497520'), True)
-    assert_equals(notisbn('9780826497529', level='strict'), False)
-    assert_equals(notisbn('9426497529', level='strict'), True)
-    assert_equals(notisbn('978082649752', level='strict'), True)
-    assert_equals(notisbn('978082649752', level='loose'), True)
-    assert_equals(notisbn('9780826400001', level='loose'), False)
-    assert_equals(notisbn('9780826400001', level='strict'), True)
-    assert_equals(notisbn('9780826400001', level='badlevel'), None)
-    assert_equals(notisbn('978 9426497529'), True)
-    assert_equals(notisbn('9789426497529'), True)
-    assert_equals(notisbn('979 10 9063607 1'), False)
-    assert_equals(notisbn('9780826497520'), True)
+    assert notisbn('0826497527') == False
+    assert notisbn('0826497520') == True
+    assert notisbn('9780826497529', level='strict') == False
+    assert notisbn('9426497529', level='strict') == True
+    assert notisbn('978082649752', level='strict') == True
+    assert notisbn('978082649752', level='loose') == True
+    assert notisbn('9780826400001', level='loose') == False
+    assert notisbn('9780826400001', level='strict') == True
+    assert notisbn('9780826400001', level='badlevel') == None
+    assert notisbn('978 9426497529') == True
+    assert notisbn('9789426497529') == True
+    assert notisbn('979 10 9063607 1') == False
+    assert notisbn('9780826497520') == True
 
 
 def test_get_isbnlike():
     """Test the extraction of ISBN-like strings."""
-    assert_equals(len(get_isbnlike(ISBNs)), 79)
-    assert_equals(len(get_isbnlike(ISBNs, 'normal')), 79)
-    assert_equals(len(get_isbnlike(ISBNs, 'strict')), 69)
-    assert_equals(len(get_isbnlike(ISBNs, 'loose')), 81)
-    assert_equals(get_isbnlike(ISBNs, 'e'), [])
+    assert len(get_isbnlike(ISBNs)) == 79
+    assert len(get_isbnlike(ISBNs, 'normal')) == 79
+    assert len(get_isbnlike(ISBNs, 'strict')) == 69
+    assert len(get_isbnlike(ISBNs, 'loose')) == 81
+    assert get_isbnlike(ISBNs, 'e') == []
     # issue 60 and 103
     # TODO add test...
     # issue 107
-    assert_equals(get_isbnlike('978-0-9790173-4-6', 'normal')[0], '978-0-9790173-4-6')
-    assert_equals(get_isbnlike('978-9788461784', 'normal')[0], '978-9788461784')
+    assert get_isbnlike('978-0-9790173-4-6', 'normal')[0] == '978-0-9790173-4-6'
+    assert get_isbnlike('978-9788461784', 'normal')[0] == '978-9788461784'
 
 
 def test_get_canonical_isbn():
     """Test the extraction of canonical ISBN from ISBN-like string."""
-    assert_equals(get_canonical_isbn('0826497527', output='bouth'), '0826497527')
-    assert_equals(get_canonical_isbn('0826497527'), '0826497527')
-    assert_equals(get_canonical_isbn('0826497527', output='isbn10'), '0826497527')
-    assert_equals(get_canonical_isbn('0826497527', output='isbn13'), '9780826497529')
-    assert_equals(
-        get_canonical_isbn('ISBN 0826497527', output='isbn13'), '9780826497529',
-    )
-    assert_equals(get_canonical_isbn('ISBN 0826497527', output='NOOPTION'), '')
-    assert_equals(get_canonical_isbn('0826497520'), '')
-    assert_equals(get_canonical_isbn('9780826497529'), '9780826497529')
-    assert_equals(get_canonical_isbn('9780826497520'), '')
-    assert_equals(get_canonical_isbn('OSX 9780826497529.pdf'), '9780826497529')
+    assert get_canonical_isbn('0826497527', output='bouth') == '0826497527'
+    assert get_canonical_isbn('0826497527') == '0826497527'
+    assert get_canonical_isbn('0826497527', output='isbn10') == '0826497527'
+    assert get_canonical_isbn('0826497527', output='isbn13') == '9780826497529'
+    assert (
+        get_canonical_isbn('ISBN 0826497527', output='isbn13') == '9780826497529')
+    assert get_canonical_isbn('ISBN 0826497527', output='NOOPTION') == ''
+    assert get_canonical_isbn('0826497520') == ''
+    assert get_canonical_isbn('9780826497529') == '9780826497529'
+    assert get_canonical_isbn('9780826497520') == ''
+    assert get_canonical_isbn('OSX 9780826497529.pdf') == '9780826497529'
 
 
 def test_canonical():
     """Test the extraction of 'only numbers and X' from ISBN-like string."""
-    assert_equals(canonical('ISBN 9789720404427'), '9789720404427')
-    assert_equals(canonical('ISBN-9780826497529'), '9780826497529')
-    assert_equals(canonical('ISBN9780826497529'), '9780826497529')
-    assert_equals(canonical('isbn9780826497529'), '9780826497529')
-    assert_equals(canonical('isbn 0826497527'), '0826497527')
-    assert_equals(canonical('954430603x'), '954430603X')
-    assert_equals(canonical('95443060x3'), '')
-    assert_equals(canonical('0000000000'), '')
-    assert_equals(canonical('000000000X'), '')
-    assert_equals(canonical('0000000000000'), '')
-    assert_equals(canonical('0000000'), '')
-    assert_equals(canonical(''), '')
+    assert canonical('ISBN 9789720404427') == '9789720404427'
+    assert canonical('ISBN-9780826497529') == '9780826497529'
+    assert canonical('ISBN9780826497529') == '9780826497529'
+    assert canonical('isbn9780826497529') == '9780826497529'
+    assert canonical('isbn 0826497527') == '0826497527'
+    assert canonical('954430603x') == '954430603X'
+    assert canonical('95443060x3') == ''
+    assert canonical('0000000000') == ''
+    assert canonical('000000000X') == ''
+    assert canonical('0000000000000') == ''
+    assert canonical('0000000') == ''
+    assert canonical('') == ''
 
 
 def test_ean13():
     """Test the extraction and validation of EAN13 from ISBN-like string."""
-    assert_equals(ean13('ISBN 9789720404427'), '')
-    assert_equals(ean13('ISBN 9789720404428'), '9789720404428')
-    assert_equals(EAN13('ISBN-9780826497529'), '9780826497529')
-    assert_equals(ean13('ISBN9780826497529'), '9780826497529')
-    assert_equals(EAN13('isbn9780826497529'), '9780826497529')
-    assert_equals(EAN13('isbn 0826497527'), '9780826497529')
-    assert_equals(ean13('9700000000000'), '')
-    assert_equals(EAN13('9000000000000'), '')
-    assert_equals(EAN13('9710000000000'), '')
+    assert ean13('ISBN 9789720404427') == ''
+    assert ean13('ISBN 9789720404428') == '9789720404428'
+    assert EAN13('ISBN-9780826497529') == '9780826497529'
+    assert ean13('ISBN9780826497529') == '9780826497529'
+    assert EAN13('isbn9780826497529') == '9780826497529'
+    assert EAN13('isbn 0826497527') == '9780826497529'
+    assert ean13('9700000000000') == ''
+    assert EAN13('9000000000000') == ''
+    assert EAN13('9710000000000') == ''

--- a/isbnlib/test/test_data.py
+++ b/isbnlib/test/test_data.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # flake8: noqa
 # pylint: skip-file
-"""nose tests"""
+"""tests"""
 
-from nose.tools import assert_equals, assert_raises
+import pytest
 
 from ..dev import Metadata, stdmeta
 from ..dev._bouth23 import u
@@ -44,10 +44,12 @@ def test_stdmeta():
         'Language': u('en'),
         'Authors': u('author1'),
     }
-    assert_equals(stdmeta(r), R)
-    assert_equals(stdmeta(R), R)
-    assert_raises(Exception, stdmeta, A)
-    assert_raises(Exception, stdmeta, B)
+    assert stdmeta(r) == R
+    assert stdmeta(R) == R
+    with pytest.raises(Exception):
+        stdmeta(A)
+    with pytest.raises(Exception):
+        stdmeta(B)
 
 
 def test_metaclass():
@@ -61,7 +63,7 @@ def test_metaclass():
         'Authors': [u('author1. mba'), u('author2')],
     }
     dt = Metadata(R)
-    assert_equals(dt.value, R)
+    assert dt.value == R
 
 
 def test_metrge():
@@ -84,4 +86,4 @@ def test_metrge():
     }
     dt = Metadata(R)
     dt.merge(T)
-    assert_equals(dt.value, T)
+    assert dt.value == T

--- a/isbnlib/test/test_editions.py
+++ b/isbnlib/test/test_editions.py
@@ -9,55 +9,55 @@ except:  # for py2
 
     timer = timeit.default_timer
 
-from nose.tools import assert_equals, raises
+import pytest
 
 from .._exceptions import NotRecognizedServiceError, NotValidISBNError
 from .._ext import editions
 
-# nose tests
+# tests
 
 
 def test_editions_openl():
     """Test the 'openl editions' service."""
-    assert_equals(len(editions('9780151446476', service='openl')) > 2, True)
+    assert len(editions('9780151446476', service='openl')) > 2 == True
 
 
 def test_editions_thingl():
     """Test the 'thingl editions' service."""
-    assert_equals(len(editions('9780151446476', service='thingl')) > 2, True)
+    assert (len(editions('9780151446476', service='thingl')) > 2) == True
 
 
 def test_editions_wiki():
     """Test the 'wiki editions' service."""
-    assert_equals(len(editions('9780440414803', service='wiki')) > 5, True)
+    assert (len(editions('9780440414803', service='wiki')) > 5) == True
 
 
 def test_editions_any():
     """Test the 'any editions' service."""
-    assert_equals(len(editions('9780151446476', service='any')) > 1, True)
+    assert (len(editions('9780151446476', service='any')) > 1) == True
 
 
 def test_editions_merge():
     """Test the 'merge editions' service."""
-    assert_equals(len(editions('9780151446476', service='merge')) > 2, True)
+    assert (len(editions('9780151446476', service='merge')) > 2) == True
 
 
-@raises(NotValidISBNError)
 def test_editions_NotValidISBNError():
     """Test the 'editions' service error detection (NotValidISBNError)."""
-    editions('978')
+    with pytest.raises(NotValidISBNError):
+        editions('978')
 
 
-@raises(NotRecognizedServiceError)
 def test_editions_NotRecognizedServiceError():
     """Test the 'editions' service error detection (NotRecognizedServiceError)."""
-    editions('9780156001311', service='xxx')
+    with pytest.raises(NotRecognizedServiceError):
+        editions('9780156001311', service='xxx')
 
 
 def test_cache():
     """Test the 'editions' cache."""
     t = timer()
-    assert_equals(len(editions('9780151446476', service='merge')) > 19, True)
+    assert (len(editions('9780151446476', service='merge')) > 19) == True
     elapsed_time = timer() - t
     millis = int(elapsed_time * 1000)
-    assert_equals(millis < 100, True)
+    assert (millis < 100) == True

--- a/isbnlib/test/test_exceptions.py
+++ b/isbnlib/test/test_exceptions.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # flake8: noqa
 # pylint: skip-file
-"""nose tests for Exceptions."""
+"""tests for Exceptions."""
 
-from nose.tools import assert_equals, assert_raises
+import pytest
 
 from .. import ISBNLibException
 from .._ext import meta
@@ -11,7 +11,8 @@ from .._ext import meta
 
 def test_catchall():
     """Test the 'catch all' exception (ISBNLibException)."""
-    assert_raises(Exception, meta, '9781849692343', 'goob', None)
+    with pytest.raises(Exception):
+        meta('9781849692343', 'goob', None)
 
     def f1():
         try:
@@ -19,7 +20,7 @@ def test_catchall():
         except ISBNLibException as ex:
             return str(ex.message)
 
-    assert_equals(f1(), '(9781849692343) is not a valid ISBN')
+    assert f1() == '(9781849692343) is not a valid ISBN'
 
     def f2():
         try:
@@ -27,7 +28,7 @@ def test_catchall():
         except ISBNLibException as ex:
             return str(ex.message)
 
-    assert_equals(f2(), '(xxx) is not a recognized service')
+    assert f2() == '(xxx) is not a recognized service'
 
 
 # NOTE the tests for other Exceptions are spread in the other tests

--- a/isbnlib/test/test_ext.py
+++ b/isbnlib/test/test_ext.py
@@ -2,63 +2,64 @@
 # flake8: noqa
 # pylint: skip-file
 
-from nose.tools import assert_equals, assert_raises
+import pytest
 
 from .._ext import cover, desc, doi, isbn_from_words, mask
 
-# nose tests
+# tests
 
 
 def test_mask():
     """Test 'mask' command."""
-    assert_equals(mask('5852700010'), '5-85270-001-0')
-    assert_equals(mask('0330284983'), '0-330-28498-3')
-    assert_equals(mask('3796519008'), '3-7965-1900-8')
-    assert_equals(mask('4198301271'), '4-19-830127-1')
-    assert_equals(mask('2226052577'), '2-226-05257-7')
-    assert_equals(mask('6053840572'), '605-384-057-2')
-    assert_equals(mask('7301102992'), '7-301-10299-2')
-    assert_equals(mask('8085983443'), '80-85983-44-3')
-    assert_equals(mask('9056911872'), '90-5691-187-2')
-    assert_equals(mask('9500404427'), '950-04-0442-7')
-    assert_equals(mask('9800101942'), '980-01-0194-2')
-    assert_equals(mask('9813018399'), '981-3018-39-9')
-    assert_equals(mask('9786001191251'), '978-600-119-125-1')
-    assert_equals(mask('9780321534965'), '978-0-321-53496-5')
-    assert_equals(mask('9781590593561'), '978-1-59059-356-1')
-    assert_equals(mask('9789993075899'), '978-99930-75-89-9')
-    assert_equals(mask('0-330284983'), '0-330-28498-3')
-    assert_equals(mask('9791090636071'), '979-10-90636-07-1')
-    assert_equals(mask('9786131796364'), '978-613-1-79636-4')  # <-- prefix with 1 rule
-    assert_equals(mask('isbn 979-10-90636-07-1'), '979-10-90636-07-1')
-    assert_equals(mask(''), '')
-    assert_raises(Exception, mask, '9786')
-    assert_raises(Exception, mask, '0000000000000')
+    assert mask('5852700010') == '5-85270-001-0'
+    assert mask('0330284983') == '0-330-28498-3'
+    assert mask('3796519008') == '3-7965-1900-8'
+    assert mask('4198301271') == '4-19-830127-1'
+    assert mask('2226052577') == '2-226-05257-7'
+    assert mask('6053840572') == '605-384-057-2'
+    assert mask('7301102992') == '7-301-10299-2'
+    assert mask('8085983443') == '80-85983-44-3'
+    assert mask('9056911872') == '90-5691-187-2'
+    assert mask('9500404427') == '950-04-0442-7'
+    assert mask('9800101942') == '980-01-0194-2'
+    assert mask('9813018399') == '981-3018-39-9'
+    assert mask('9786001191251') == '978-600-119-125-1'
+    assert mask('9780321534965') == '978-0-321-53496-5'
+    assert mask('9781590593561') == '978-1-59059-356-1'
+    assert mask('9789993075899') == '978-99930-75-89-9'
+    assert mask('0-330284983') == '0-330-28498-3'
+    assert mask('9791090636071') == '979-10-90636-07-1'
+    assert mask('9786131796364') == '978-613-1-79636-4'  # <-- prefix with 1 rule
+    assert mask('isbn 979-10-90636-07-1') == '979-10-90636-07-1'
+    assert mask('') == ''
+    with pytest.raises(Exception):
+        mask('9786')
+    with pytest.raises(Exception):
+        mask('0000000000000')
 
 
 def test_isbn_from_words():
     """Test 'isbn_from_words' command."""
-    assert_equals(len(isbn_from_words('old men and sea')), 13)
+    assert len(isbn_from_words('old men and sea')) == 13
 
 
 def test_doi():
     """Test 'doi' command."""
-    assert_equals(doi('9780195132861'), '10.978.019/5132861')
-    assert_equals(doi('9780321534965'), '10.978.0321/534965')
-    assert_equals(doi('9791090636071'), '10.979.1090636/071')
+    assert doi('9780195132861') == '10.978.019/5132861'
+    assert doi('9780321534965') == '10.978.0321/534965'
+    assert doi('9791090636071') == '10.979.1090636/071'
 
 
 def test_desc():
     """Test 'desc' command."""
-    assert_equals(len(desc('9780156001311')) > 10, True)
-    assert_equals(desc('9780000000000'), '')
+    assert (len(desc('9780156001311')) > 10) == True
+    assert desc('9780000000000') == ''
 
 
 def test_cover():
     """Test 'cover' command."""
-    assert_equals(len(repr(cover('9780156001311'))) > 50, True)
-    assert_equals(cover('9780000000000'), {})  # <-- invalid ISBN
-    assert_equals(len(repr(cover('9781408835029'))) > 50, True)
-    assert_equals(
-        len(repr(cover('9789727576807'))) < 50, True,
-    )  # <-- no image of any size
+    assert (len(repr(cover('9780156001311'))) > 50) == True
+    assert cover('9780000000000') == {}  # <-- invalid ISBN
+    assert (len(repr(cover('9781408835029'))) > 50) == True
+    assert (
+        (len(repr(cover('9789727576807'))) < 50) == True)  # <-- no image of any size

--- a/isbnlib/test/test_files.py
+++ b/isbnlib/test/test_files.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # flake8: noqa
 # pylint: skip-file
-""" nose tests
+""" tests
 
 """
 

--- a/isbnlib/test/test_fmt.py
+++ b/isbnlib/test/test_fmt.py
@@ -2,10 +2,8 @@
 # flake8: noqa
 # pylint: skip-file
 """
-nose tests
+tests
 """
-
-from nose.tools import assert_equals
 
 from ..dev._bouth23 import u
 from ..dev._fmt import _fmtbib
@@ -22,12 +20,12 @@ canonical = {
 
 def test_fmtbib():
     """Test the formatting into several bibliographic formats."""
-    assert_equals(len(_fmtbib('bibtex', canonical)), 182)
-    assert_equals(len(_fmtbib('labels', canonical)), 158)
-    assert_equals(len(_fmtbib('endnote', canonical)), 103)
-    assert_equals(len(_fmtbib('msword', canonical)), 485)
-    assert_equals(len(_fmtbib('json', canonical)), 229)
-    assert_equals(len(_fmtbib('csl', canonical)), 253)
-    assert_equals(len(_fmtbib('csv', canonical)), 94)
-    assert_equals(len(_fmtbib('ris', canonical)), 130)
-    assert_equals(len(_fmtbib('opf', canonical)), 861)
+    assert len(_fmtbib('bibtex', canonical)) == 182
+    assert len(_fmtbib('labels', canonical)) == 158
+    assert len(_fmtbib('endnote', canonical)) == 103
+    assert len(_fmtbib('msword', canonical)) == 485
+    assert len(_fmtbib('json', canonical)) == 229
+    assert len(_fmtbib('csl', canonical)) == 253
+    assert len(_fmtbib('csv', canonical)) == 94
+    assert len(_fmtbib('ris', canonical)) == 130
+    assert len(_fmtbib('opf', canonical)) == 861

--- a/isbnlib/test/test_goom.py
+++ b/isbnlib/test/test_goom.py
@@ -2,15 +2,13 @@
 # flake8: noqa
 # pylint: skip-file
 """
-nose tests
+tests
 """
-
-from nose.tools import assert_equals
 
 from .. import _goom as goom
 
 
 def test_goom():
     """Test the Google's Multiple Books service."""
-    assert_equals(len(repr(goom.query('the old man and the sea'))) > 500, True)
-    assert_equals(len(repr(goom.query('plato republic'))) > 500, True)
+    assert (len(repr(goom.query('the old man and the sea'))) > 500) == True
+    assert (len(repr(goom.query('plato republic'))) > 500) == True

--- a/isbnlib/test/test_helpers.py
+++ b/isbnlib/test/test_helpers.py
@@ -2,56 +2,46 @@
 # flake8: noqa
 # pylint: skip-file
 """
-nose tests
+tests
 """
-
-from nose.tools import assert_equals
 
 from ..dev._helpers import cutoff_tokens, fake_isbn, last_first, parse_placeholders
 
 
 def test_last_first():
     """Test the parsing of author's name into (Surname, First Name)."""
-    assert_equals(
-        last_first('Surname, First Name'), {'last': 'Surname', 'first': 'First Name'},
-    )
-    assert_equals(
-        last_first('First Name Surname'), {'last': 'Surname', 'first': 'First Name'},
-    )
-    assert_equals(
-        last_first('Surname1, First1 and Sur2, First2'),
-        {'last': 'Surname1', 'first': 'First1 and Sur2, First2'},
-    )
+    assert (
+        last_first('Surname, First Name') == {'last': 'Surname', 'first': 'First Name'})
+    assert (
+        last_first('First Name Surname') == {'last': 'Surname', 'first': 'First Name'})
+    assert (
+        last_first('Surname1, First1 and Sur2, First2') ==
+        {'last': 'Surname1', 'first': 'First1 and Sur2, First2'})
 
 
 def test_cutoff_tokens():
     """Test the 'cutoff_tokens' function."""
-    assert_equals(cutoff_tokens(['1', '23', '456'], 3), ['1', '23'])
+    assert cutoff_tokens(['1', '23', '456'], 3) == ['1', '23']
 
 
 def test_parse_placeholders():
     """Test the parsing of placeholders."""
-    assert_equals(parse_placeholders('{isbn}_akaj_{name}'), ['{isbn}', '{name}'])
+    assert parse_placeholders('{isbn}_akaj_{name}') == ['{isbn}', '{name}']
 
 
 def test_fake_isbn():
     """Test the 'fake_isbn' function."""
-    assert_equals(fake_isbn(' Hello?? Wer,  ! ksDf:  asdf. ; '), '1111006407537')
-    assert_equals(
-        fake_isbn(' Hello?? Wer,  ! ksDf:  asdf. ; ', author=''), '1108449680873',
-    )
-    assert_equals(
-        fake_isbn(' Hello?? Wer,  ! ksDf:  asdf. ; ', author=' '), '1108449680873',
-    )
-    assert_equals(
-        fake_isbn(' Hello?? Wer,  ! ksDf:  asdf. ; ', author='', publisher=''),
-        '1181593982422',
-    )
-    assert_equals(
-        fake_isbn(' Hello?? Wer,  ! ksDf:  asdf. ; ', author='a', publisher='K'),
-        '1895031085488',
-    )
-    assert_equals(
-        fake_isbn(' Hello?? Wer,  ! ksDf:  asdf. ; ', author='A', publisher='k'),
-        '1895031085488',
-    )
+    assert fake_isbn(' Hello?? Wer,  ! ksDf:  asdf. ; ') == '1111006407537'
+    assert (
+        fake_isbn(' Hello?? Wer,  ! ksDf:  asdf. ; ', author='') == '1108449680873')
+    assert (
+        fake_isbn(' Hello?? Wer,  ! ksDf:  asdf. ; ', author=' ') == '1108449680873')
+    assert (
+        fake_isbn(' Hello?? Wer,  ! ksDf:  asdf. ; ', author='', publisher='') ==
+        '1181593982422')
+    assert (
+        fake_isbn(' Hello?? Wer,  ! ksDf:  asdf. ; ', author='a', publisher='K') ==
+        '1895031085488')
+    assert (
+        fake_isbn(' Hello?? Wer,  ! ksDf:  asdf. ; ', author='A', publisher='k') ==
+        '1895031085488')

--- a/isbnlib/test/test_info.py
+++ b/isbnlib/test/test_info.py
@@ -2,35 +2,38 @@
 # flake8: noqa
 # pylint: skip-file
 
-from nose.tools import assert_equals, assert_raises
+import pytest
 
 from .._ext import info
 from .._infogroup import infogroup
 
 
-# nose tests
+# tests
 def test_infogroup():
     """Test 'infogroup' language/country function."""
-    assert_equals(infogroup('9789727576807'), 'Portugal')
-    assert_equals(infogroup('978-972-757-680-7'), 'Portugal')
-    assert_equals(infogroup('7500117019'), "China, People's Republic")
-    assert_equals(infogroup('7-5001-1701-9'), "China, People's Republic")
-    assert_equals(infogroup('9524712946'), 'Finland')
-    assert_equals(infogroup('0330284983'), 'English language')
-    assert_equals(infogroup('3796519008'), 'German language')
-    assert_raises(Exception, infogroup, '92xxxxxxxxxxx')
-    assert_raises(Exception, infogroup, '')
-    assert_equals(infogroup('9791090636071'), 'France')
-    assert_equals(infogroup('9786131796364'), 'Mauritius')
-    assert_equals(infogroup('9789992158104'), 'Qatar')
+    assert infogroup('9789727576807') == 'Portugal'
+    assert infogroup('978-972-757-680-7') == 'Portugal'
+    assert infogroup('7500117019') == "China, People's Republic"
+    assert infogroup('7-5001-1701-9') == "China, People's Republic"
+    assert infogroup('9524712946') == 'Finland'
+    assert infogroup('0330284983') == 'English language'
+    assert infogroup('3796519008') == 'German language'
+    with pytest.raises(Exception):
+        infogroup('92xxxxxxxxxxx')
+    with pytest.raises(Exception):
+        infogroup('')
+    assert infogroup('9791090636071') == 'France'
+    assert infogroup('9786131796364') == 'Mauritius'
+    assert infogroup('9789992158104') == 'Qatar'
 
 
 def test_ext_info():
     """Test 'info' language/country function."""
-    assert_equals(info('9524712946'), 'Finland')
-    assert_raises(Exception, info, '')
+    assert info('9524712946') == 'Finland'
+    with pytest.raises(Exception):
+        info('')
 
 
 def test_ext_info():
     """Test 'info' not issued ISBN."""
-    assert_equals(info('9789999999991'), '')
+    assert info('9789999999991') == ''

--- a/isbnlib/test/test_isbn.py
+++ b/isbnlib/test/test_isbn.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # flake8: noqa
 # pylint: skip-file
-"""nose tests"""
+"""tests"""
 
-from nose.tools import assert_equals, assert_raises
+import pytest
 
 from .._isbn import Isbn
 
@@ -12,43 +12,39 @@ isbn=Isbn('9781250158062')
 
 def test_ean13():
     """Test the 'Isbn class' for ean13."""
-    assert_equals(isbn.ean13, '9781250158062')
+    assert isbn.ean13 == '9781250158062'
 
 def test_isbn13():
     """Test the 'Isbn class' for isbn13."""
-    assert_equals(isbn.isbn13, '978-1-250-15806-2')
+    assert isbn.isbn13 == '978-1-250-15806-2'
 
 def test_isbn10():
     """Test the 'Isbn class' for isbn10."""
-    assert_equals(isbn.isbn10, '1-250-15806-0')
+    assert isbn.isbn10 == '1-250-15806-0'
 
 def test_doi():
     """Test the 'Isbn class' for doi."""
-    assert_equals(isbn.doi, '10.978.1250/158062')
+    assert isbn.doi == '10.978.1250/158062'
 
 def test_issued():
     """Test the 'Isbn class' for 'issued'."""
-    assert_equals(isbn.issued, True)
+    assert isbn.issued == True
     isbn2=Isbn('9786610326266')
-    assert_equals(isbn2.issued, False)
+    assert isbn2.issued == False
 
 def test_info():
     """Test the 'Isbn class' for 'info'."""
-    assert_equals(isbn.info, 'English language')
+    assert isbn.info == 'English language'
 
 def test_errors():
     """Test the 'Isbn class' for 'bad isbn'."""
-    assert_raises(Exception, Isbn, '781250158062')
+    with pytest.raises(Exception):
+        Isbn('781250158062')
 
 def test_str():
     """Test the 'Isbn class' for 'str'."""
-    assert_equals(len(str(isbn)) > 20,  True)
+    assert (len(str(isbn)) > 20) ==  True
 
 def test_repr():
     """Test the 'Isbn class' for 'repr'."""
-    assert_equals(len(repr(isbn)) > 20,  True)
-
-
-
-
-
+    assert (len(repr(isbn)) > 20) ==  True

--- a/isbnlib/test/test_metadata.py
+++ b/isbnlib/test/test_metadata.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 # flake8: noqa
 # pylint: skip-file
-"""nose tests for metadata."""
+"""tests for metadata."""
 
 from random import randrange
 
-from nose.tools import assert_equals, assert_raises
+import pytest
 
 from .._ext import meta
 from .._metadata import query
@@ -14,22 +14,29 @@ from .._metadata import query
 def test_query():
     """Test the query of metadata with 'low level' queries."""
     # test query from metadata
-    assert_raises(Exception, query, '9781849692341', 'goog')
-    assert_raises(Exception, query, '9781849692343', 'goob')
+    with pytest.raises(Exception):
+        query('9781849692341', 'goob')
+    with pytest.raises(Exception):
+        query('9781849692343', 'goob')
     # assert_equals(query('9789934015960', 'goob'), {})
-    assert_equals(len(repr(query('9780321534965'))) > 100, True)
-    assert_equals(len(repr(query('9780321534965', 'goob'))) > 100, True)
+    assert (len(repr(query('9780321534965'))) > 100) == True
+    assert (len(repr(query('9780321534965', 'goob'))) > 100) == True
     # assert_equals(len(repr(query('9789934015960'))) > 100, True)
-    assert_equals(len(repr(query(u'9781118241257'))) > 100, True)
-    assert_raises(Exception, query, '9780000000', 'goob')
-    assert_raises(Exception, query, randrange(0, 1000000), 'goob')
+    assert (len(repr(query(u'9781118241257'))) > 100) == True
+    with pytest.raises(Exception):
+        query('9780000000', 'goob')
+    with pytest.raises(Exception):
+        query(randrange(0, 1000000), 'goob')
 
 
 def test_ext_meta():
     """Test the query of metadata with 'high level' meta function."""
     # test meta from core
-    assert_equals(len(repr(meta('9780321534965', 'goob'))) > 100, True)
-    assert_equals(len(repr(meta('9780321534965'))) > 100, True)
-    assert_raises(Exception, meta, '9780000000', 'goob')
-    assert_raises(Exception, meta, randrange(0, 1000000), 'goob')
-    assert_raises(Exception, meta, '9781849692343', 'goob')
+    assert (len(repr(meta('9780321534965', 'goob'))) > 100) == True
+    assert (len(repr(meta('9780321534965'))) > 100) == True
+    with pytest.raises(Exception):
+        meta('9780000000', 'goob')
+    with pytest.raises(Exception):
+        meta(randrange(0, 1000000), 'goob')
+    with pytest.raises(Exception):
+        meta('9781849692343', 'goob')

--- a/isbnlib/test/test_openl.py
+++ b/isbnlib/test/test_openl.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 # flake8: noqa
 # pylint: skip-file
-""" nose tests
+"""
+tests
 """
 
-from nose.tools import assert_equals
+import pytest
 
 from .._metadata import query
 
@@ -12,5 +13,5 @@ from .._metadata import query
 def test_query():
     """Test 'openl' metadata service."""
     # test query from metadata
-    assert_equals(len(repr(query('9780195132861', 'openl'))) > 140, True)
-    assert_equals(len(repr(query('9780156001311', 'openl'))) > 140, True)
+    assert (len(repr(query('9780195132861', 'openl'))) > 140) == True
+    assert (len(repr(query('9780156001311', 'openl'))) > 140) == True

--- a/isbnlib/test/test_registry.py
+++ b/isbnlib/test/test_registry.py
@@ -2,23 +2,29 @@
 # flake8: noqa
 # pylint: skip-file
 
-from nose.tools import assert_equals, assert_raises
+import pytest
 
 from ..registry import setdefaultbibformatter, setdefaultservice
 
 
-# nose tests
+# tests
 def test_setdefaultbibformatter():
     """Test setdefaultbibformatter."""
-    assert_equals(setdefaultbibformatter('json'), None)
-    assert_raises(Exception, setdefaultbibformatter, 'default')
-    assert_raises(Exception, setdefaultbibformatter, '')
-    assert_raises(Exception, setdefaultbibformatter, 'xxx')
+    assert setdefaultbibformatter('json') == None
+    with pytest.raises(Exception):
+        setdefaultbibformatter('default')
+    with pytest.raises(Exception):
+        setdefaultbibformatter('')
+    with pytest.raises(Exception):
+        setdefaultbibformatter('xxx')
 
 
 def test_setdefaultservice():
     """Test setdefaultservice."""
-    assert_equals(setdefaultservice('goob'), None)
-    assert_raises(Exception, setdefaultservice, 'default')
-    assert_raises(Exception, setdefaultservice, '')
-    assert_raises(Exception, setdefaultservice, 'xxx')
+    assert setdefaultservice('goob') == None
+    with pytest.raises(Exception):
+        setdefaultservice('default')
+    with pytest.raises(Exception):
+        setdefaultservice('')
+    with pytest.raises(Exception):
+        setdefaultservice('xxx')

--- a/isbnlib/test/test_rename.py
+++ b/isbnlib/test/test_rename.py
@@ -2,13 +2,11 @@
 # flake8: noqa
 # pylint: skip-file
 """
-nose tests
+tests
 """
 
 import locale
 import os
-
-from nose.tools import assert_equals
 
 from .._ext import ren
 from ..dev._bouth23 import b2u3
@@ -81,8 +79,8 @@ def teardown_module():
 def test_ren():
     """Test 'high level' ren function."""
     ren(F1)
-    assert_equals(F7 in cwdfiles('*.pdf'), True)
-    # assert_equals(F7 in cwdfiles("*.pdf") or F7a in cwdfiles("*.pdf"), True)
+    assert (F7 in cwdfiles('*.pdf')) == True
+    # assert F7 in cwdfiles("*.pdf") or F7a in cwdfiles("*.pdf") is True
     # create_files([F5])
     # ren(F5)
-    # assert_equals('Campos2011_Emergências obstétricas_9789727576807.pdf' in cwdfiles("*.pdf"), True)
+    # assert 'Campos2011_Emergências obstétricas_9789727576807.pdf' in cwdfiles("*.pdf") is True

--- a/isbnlib/test/test_unicode_to_utf8tex.py
+++ b/isbnlib/test/test_unicode_to_utf8tex.py
@@ -2,15 +2,13 @@
 # flake8: noqa
 # pylint: skip-file
 """
-nose tests
+tests
 """
-
-from nose.tools import assert_equals
 
 from ..dev._helpers import unicode_to_utf8tex
 
 
 def test_unicode_to_utf8tex():
     """Test 'unicode_to_utf8tex' identity transformation."""
-    assert_equals(unicode_to_utf8tex(u'\u00E2 \u00F5'), b'\^{a}\space \~{o}')
-    assert_equals(unicode_to_utf8tex(u'\u00E2 \u00F5', (b'\\space ',)), b'\^{a} \~{o}')
+    assert unicode_to_utf8tex(u'\u00E2 \u00F5') == b'\^{a}\space \~{o}'
+    assert unicode_to_utf8tex(u'\u00E2 \u00F5', (b'\\space ',)) == b'\^{a} \~{o}'

--- a/isbnlib/test/test_vias.py
+++ b/isbnlib/test/test_vias.py
@@ -2,13 +2,11 @@
 # flake8: noqa
 # pylint: skip-file
 """
-nose tests
+tests
 """
 
 import os
 import platform
-
-from nose.tools import assert_equals
 
 from ..dev import vias
 
@@ -28,7 +26,7 @@ def test_vias_serial():
     data1 = results.get('task1', 0)
     data2 = results.get('task2', 0)
     data = data1 + data2
-    assert_equals(data, 5 * 5 + 5 + 5)
+    assert data == 5 * 5 + 5 + 5
 
 
 def test_vias_parallel():
@@ -38,7 +36,7 @@ def test_vias_parallel():
     data1 = results.get('task1', 0)
     data2 = results.get('task2', 0)
     data = data1 + data2
-    assert_equals(data, 5 * 5 + 5 + 5)
+    assert data == 5 * 5 + 5 + 5
 
 
 def test_vias_multi():
@@ -53,4 +51,4 @@ def test_vias_multi():
     data1 = results.get('task1', 0)
     data2 = results.get('task2', 0)
     data = data1 + data2
-    assert_equals(data, 5 * 5 + 5 + 5)
+    assert data == 5 * 5 + 5 + 5

--- a/isbnlib/test/test_webservice.py
+++ b/isbnlib/test/test_webservice.py
@@ -2,16 +2,13 @@
 # flake8: noqa
 # pylint: skip-file
 """
-nose tests
+tests
 """
-
-from nose.tools import assert_equals
 
 from ..dev.webservice import query as wsquery
 
 
 def test_webservice():
     """Test that values can be passed to a WebService query."""
-    assert_equals(
-        len(repr(wsquery('http://example.org', values={'some': 'values'}))) > 0, True,
-    )
+    assert (
+        (len(repr(wsquery('http://example.org', values={'some': 'values'}))) > 0) == True)

--- a/isbnlib/test/test_wiki.py
+++ b/isbnlib/test/test_wiki.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 # flake8: noqa
 # pylint: skip-file
-""" nose tests for wikipedia."""
-
-from nose.tools import assert_equals
+""" tests for wikipedia."""
 
 from .._metadata import query
 
@@ -11,8 +9,8 @@ from .._metadata import query
 def test_query():
     """Test 'wiki' metadata service."""
     # test query from metadata
-    assert_equals(len(repr(query('9780195132861', 'wiki'))) > 100, True)
-    assert_equals(len(repr(query('9780375869020', 'wiki'))) > 100, True)
+    assert (len(repr(query('9780195132861', 'wiki'))) > 100) == True
+    assert (len(repr(query('9780375869020', 'wiki'))) > 100) == True
     data = query('9780596003302', 'wiki')
-    assert_equals(len(repr(data['Authors'])) > 5, True)
-    assert_equals(len(repr(data['Publisher'])) > 5, True)
+    assert (len(repr(data['Authors'])) > 5) == True
+    assert (len(repr(data['Publisher'])) > 5) == True

--- a/isbnlib/test/test_words.py
+++ b/isbnlib/test/test_words.py
@@ -2,16 +2,14 @@
 # flake8: noqa
 # pylint: skip-file
 """
-nose tests
+tests
 """
-
-from nose.tools import assert_equals
 
 from .. import _gwords as words
 
 
 def test_words():
     """Test 'isbn_from_words' function."""
-    assert_equals(len(words.goos('the old man and the sea')), 13)
-    #assert_equals(len(words.goos('Pessoa Desassossego')), 13)
-    # assert_equals(words.goos('-ISBN -isbn') in ('9781364200329', None), True)
+    assert len(words.goos('the old man and the sea')) == 13
+    # assert len(words.goos('Pessoa Desassossego')) == 13
+    # assert words.goos('-ISBN -isbn') in ('9781364200329', None) == True

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,6 +11,6 @@ flake8-mutable==1.2.0
 flake8-pep3101==1.3.0
 flake8-string-format==0.3.0
 flake8-tidy-imports==4.8.0
-nose==1.3.7
 pep8-naming==0.13.2
+pytest==7.1.3
 yapf==0.32.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,15 +24,6 @@ classifier=
 universal=1
 
 
-
-[nosetests]
-verbosity=1
-with-coverage=1
-cover-package=isbnlib
-cover-branches=1
-cover-min-percentage=90
-
-
 [flake8]
 max-line-length=88
 exclude=*/test/*,*/_data/*
@@ -71,8 +62,8 @@ ignore=E701,E70,E702,W503
 max-line-length=80
 
 
-[tool:pytest]
-addopts = --cov=isbnlib
+# [tool:pytest]
+# addopts = --cov=isbnlib
 
 
 [coverage:run]


### PR DESCRIPTION
**IMPORTANT**

Fixes #92
Fixes #93
Fixes #95
Similar to xlcnd/isbntools#119

Make your pull request against the ``dev`` branch, please!


On follow-up of issue #95


Changes proposed in this pull request:

- Run https://pypi.org/project/nose2pytest (on Python 3.6!!) to upgrade Python testing from nose to pytest.
- I am unsure why `pytest --ignore=isbnlib/test/test_editions.py --ignore=isbnlib/test/test_openl.py` is required.
- After this is merged, there will be a todo to wire together `pytest` and `cov`.

@xlcnd
