### PR TITLE
Undo double negation

### DIFF
--- a/isbnlib/_core.py
+++ b/isbnlib/_core.py
@@ -105,7 +105,7 @@ def is_isbn10(isbn10):
     isbn10 = canonical(isbn10)
     if len(isbn10) != 10:
         return False  # pragma: no cover
-    return bool(not check_digit10(isbn10[:-1]) != isbn10[-1])
+    return bool(check_digit10(isbn10[:-1]) == isbn10[-1])
 
 
 def is_isbn13(isbn13):
@@ -115,7 +115,7 @@ def is_isbn13(isbn13):
         return False  # pragma: no cover
     if isbn13[0:3] not in ('978', '979'):
         return False
-    return bool(not check_digit13(isbn13[:-1]) != isbn13[-1])
+    return bool(check_digit13(isbn13[:-1]) == isbn13[-1])
 
 
 def to_isbn10(isbn13):


### PR DESCRIPTION
**IMPORTANT**

Make your pull request against the ``dev`` branch, please!

% `ruff --select=SIM202 .`
```
  2	SIM202 	[*] Use `check_digit10(isbn10[:-1]) == isbn10[-1]` instead of `not check_digit10(isbn10[:-1]) != isbn10[-1]`
```
% `ruff --select=SIM202 --fix .`
```
Found 2 errors (2 fixed, 0 remaining).
```
% `ruff rule SIM202`
# negate-not-equal-op (SIM202)

Derived from the **flake8-simplify** linter.

Autofix is always available.

## What it does
Checks for negated `!=` operators.

## Why is this bad?
Negated `!=` operators are less readable than `==` operators, as they avoid a
double negation.

## Example
```python
not a != b
```

Use instead:
```python
a == b
```

## References
- [Python documentation: Comparisons](https://docs.python.org/3/reference/expressions.html#comparisons)

@xlcnd
